### PR TITLE
Allow for wide images up to 4:1

### DIFF
--- a/OSMWikidataDetails/osm-wikidata.js
+++ b/OSMWikidataDetails/osm-wikidata.js
@@ -110,8 +110,8 @@ function displayLabelAndLink(qid, label, description, hasIcon, wikipediaLink, el
 
     if (hasIcon) {
         const brandIcon = document.createElement('img');
-        brandIcon.src = `https://hub.toolforge.org/${qid}?p=P8972,P154&w=32&h=32`;
-        brandIcon.style.height = 32;
+        brandIcon.src = `https://hub.toolforge.org/${qid}?p=P8972,P154&h=32`;
+        brandIcon.style.height = `32px`;
         brandIcon.style.display = 'block'; // New line for QID
         brandIcon.style.float = 'left'; // New line for QID
         brandIcon.style.marginRight = '8px';

--- a/OSMWikidataDetailsFF/osm-wikidata.js
+++ b/OSMWikidataDetailsFF/osm-wikidata.js
@@ -118,8 +118,8 @@ function displayLabelAndLink(qid, label, description, hasIcon, wikipediaLink, el
 
     if (hasIcon) {
         const brandIcon = document.createElement('img');
-        brandIcon.src = `https://hub.toolforge.org/${qid}?p=P8972,P154&w=32&h=32`;
-        brandIcon.style.height = 32;
+        brandIcon.src = `https://hub.toolforge.org/${qid}?p=P8972,P154&h=32&w=128`;
+        brandIcon.style.height = `32px`;
         brandIcon.style.display = 'block'; // New line for QID
         brandIcon.style.float = 'left'; // New line for QID
         brandIcon.style.marginRight = '8px';

--- a/greasemonkey/osm-wikidata.js
+++ b/greasemonkey/osm-wikidata.js
@@ -102,8 +102,8 @@ function displayLabelAndLink(qid, label, description, hasIcon, wikipediaLink, el
 
     if (hasIcon) {
         const brandIcon = document.createElement('img');
-        brandIcon.src = `https://hub.toolforge.org/${qid}?p=P8972,P154&w=32&h=32`;
-        brandIcon.style.height = 32;
+        brandIcon.src = `https://hub.toolforge.org/${qid}?p=P8972,P154&h=32&w=128`;
+        brandIcon.style.height = `32px`;
         brandIcon.style.display = 'block'; // New line for QID
         brandIcon.style.float = 'left'; // New line for QID
         brandIcon.style.marginRight = '8px';


### PR DESCRIPTION
Closes #1 

This PR allows for icons to be up to a 4:1 ratio in width, beyond which it will scale down.  This will take effect as of plugin v1.0.2

![image](https://github.com/ZeLonewolf/osm-wikidata-greasemonkey/assets/3254090/0b7da6b5-8cf9-49b7-882c-e6babb510fa3)
